### PR TITLE
Use env for conf.ini too

### DIFF
--- a/conf.ini
+++ b/conf.ini
@@ -10,7 +10,7 @@ opcache.revalidate_freq=1
 opcache.jit_buffer_size=100M
 
 session.save_handler = redis
-session.save_path = "tcp://redis:6379"
+session.save_path = "tcp://${REDIS_HOST}:6379?database=${REDIS_IDX}"
 
 expose_php = Off
 


### PR DESCRIPTION
session path is not honoring the env variable for redis.